### PR TITLE
Bump zapzap to 6.4.2

### DIFF
--- a/com.rtosta.zapzap-git.yaml
+++ b/com.rtosta.zapzap-git.yaml
@@ -50,4 +50,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/rafatosta/zapzap.git
-        tag: 6.4.1
+        tag: 6.4.2

--- a/com.rtosta.zapzap.spec
+++ b/com.rtosta.zapzap.spec
@@ -2,7 +2,7 @@
 # Based on PKGBUILD from AUR
 
 %global srcname zapzap
-%global srcversion  6.4.1
+%global srcversion  6.4.2
 
 %global __python /usr/bin/python3
 %global _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.rpm

--- a/share/metainfo/com.rtosta.zapzap.appdata.xml
+++ b/share/metainfo/com.rtosta.zapzap.appdata.xml
@@ -55,6 +55,14 @@
   </screenshots>
 
   <releases>
+      <release date="2026-05-15" version="6.4.2">
+          <description>
+              <ul>
+                  <li>Fix phone calls (WhatsApp Beta only)</li>
+                  <li>Fix display file preview.</li>
+              </ul>
+          </description>
+      </release>
       <release date="2026-05-09" version="6.4.1">
           <description>
               <ul>

--- a/zapzap/__init__.py
+++ b/zapzap/__init__.py
@@ -1,6 +1,6 @@
 from PyQt6.QtCore import QFileInfo, QUrl
 
-__version__ = '6.4.1'
+__version__ = '6.4.2'
 __appname__ = 'ZapZap'
 __comment__ = 'WhatsApp Messenger for linux'
 __domain__ = 'com.rtosta'


### PR DESCRIPTION
Update upstream to 6.4.2: bump git tag in com.rtosta.zapzap-git.yaml, update %srcversion in com.rtosta.zapzap.spec, and add a new appdata release entry describing fixes for phone calls (WhatsApp Beta only) and display file preview.